### PR TITLE
Reduced the maximum track-cluster distance permissable for a matched clu...

### DIFF
--- a/pyEudetReconstructionOnly.py
+++ b/pyEudetReconstructionOnly.py
@@ -129,6 +129,12 @@ scaler = 1
 
 if(options.NEVENT):
     n_proc= int(options.NEVENT)
+
+    if n_proc >= aDataSet.t_nEntries:
+        n_proc = -1
+    if n_proc == -1:
+        n_proc = aDataSet.t_nEntries
+
 else :
     n_proc= aDataSet.t_nEntries
 
@@ -167,7 +173,7 @@ for i in range(0,n_proc,scaler) :
         for alignement in alignment_constants :
             ApplyAlignment_at_event(ind,aDataSet,[alignement[3],alignement[4],0],[alignement[0],alignement[1],alignement[2]])
 
-        aDataSet.FindMatchedCluster(ind,0.5,6,distances_histo)
+        aDataSet.FindMatchedCluster(ind,0.1,6,distances_histo)
         m,me=aDataSet.ComputeResiduals(ind)
         n_matched+=m
         n_matched_edge+=me


### PR DESCRIPTION
...ster.

Old value was 0.5 mm, new value is 0.1 mm.
This is motivated by the histogram of track-cluster distance.

![cluster-track_dist](https://cloud.githubusercontent.com/assets/8256377/3830698/9a6993ba-1d8c-11e4-8b8d-5764e13134cc.png)

Also added a check that the requested number of events is not greater than the total
and allow the user to input -1 from the command line to mean "all events".
