### PR TITLE
Rewrite of EtaCorrection method, and improved resolution for s2x2y2 clusters. 

### DIFF
--- a/Cluster.py
+++ b/Cluster.py
@@ -169,11 +169,7 @@ class Cluster:
 
             elif(self.sizeX==2 and self.sizeY==2) :
                 # cluster size 2 with sizeX = 2 and sizeY = 2 i.e. 2 pixels on a diagonal
-                Qrel = self.tot[self.col.index(min(self.col))] / self.totalTOT
-                clu_grad = (self.col[self.row.index(min(self.row))] - self.col[self.row.index(max(self.row))]) / (min(self.row) - max(self.row))
-                shiftX,shiftY = shiftDiag(sigmaX,sigmaY,Qrel)
-                self.relX = max(self.col)*pitchX - shiftX
-                self.relY = max(self.row)*pitchY - clu_grad*shiftY
+                self.GetMaxTOTCentroid()
 
 
         elif(self.size==4) :


### PR DESCRIPTION
See commit comments. Plots here show the EtaCorrection and maxTOT reslutions for s2x2y2 clusters. 

![resx_s2x2y2_etac](https://cloud.githubusercontent.com/assets/8256377/4152703/4619bf66-3451-11e4-8a66-c1685f6927e6.png)
![resx_s2x2y2_maxtot](https://cloud.githubusercontent.com/assets/8256377/4152705/4a01184a-3451-11e4-8fa7-983d5fd2b9d8.png)
