### PR TITLE
Added HotPixelRemoval to ComputeAlignment.py

### DIFF
--- a/Cluster.py
+++ b/Cluster.py
@@ -133,8 +133,8 @@ class Cluster:
             self.relX = self.relX/self.totalTOT + pitchX/2.
             self.relY = self.relY/self.totalTOT + pitchY/2.
 
-            self.absX=self.relX - npix_X*pitchX/2.
-            self.absY=self.relY - npix_Y*pitchY/2.
+            self.absX=self.relX - halfChip_X
+            self.absY=self.relY - halfChip_Y
             self.absZ=0
 
         if ((self.totalEnergyGC > 0) and (0 not in self.energyGC)):
@@ -145,8 +145,8 @@ class Cluster:
             self.relX_energyGC = self.relX_energyGC/self.totalEnergyGC + pitchX/2.
             self.relY_energyGC = self.relY_energyGC/self.totalEnergyGC + pitchY/2.
 
-            self.absX_energyGC=self.relX_energyGC - npix_X*pitchX/2.
-            self.absY_energyGC=self.relY_energyGC - npix_Y*pitchY/2.
+            self.absX_energyGC=self.relX_energyGC - halfChip_X
+            self.absY_energyGC=self.relY_energyGC - halfChip_Y
             self.absZ_energyGC=0
 
         if ((self.totalEnergyPbPC > 0) and (0 not in self.energyPbPC)):
@@ -157,8 +157,8 @@ class Cluster:
             self.relX_energyPbPC = self.relX_energyPbPC/self.totalEnergyPbPC + pitchX/2.
             self.relY_energyPbPC = self.relY_energyPbPC/self.totalEnergyPbPC + pitchY/2.
 
-            self.absX_energyPbPC=self.relX_energyPbPC - npix_X*pitchX/2.
-            self.absY_energyPbPC=self.relY_energyPbPC - npix_Y*pitchY/2.
+            self.absX_energyPbPC=self.relX_energyPbPC - halfChip_X
+            self.absY_energyPbPC=self.relY_energyPbPC - halfChip_Y
             self.absZ_energyPbPC=0
 
 #
@@ -174,8 +174,8 @@ class Cluster:
         self.relX = self.relX/len(self.col) + pitchX/2.
         self.relY = self.relY/len(self.row) + pitchY/2.
 
-        self.absX=self.relX - npix_X*pitchX/2.
-        self.absY=self.relY - npix_Y*pitchY/2.
+        self.absX=self.relX - halfChip_X
+        self.absY=self.relY - halfChip_Y
         self.absZ=0
 
 #
@@ -192,8 +192,8 @@ class Cluster:
         self.relX=self.col[maxTOTindex_tmp]*pitchX + pitchX/2.
         self.relY=self.row[maxTOTindex_tmp]*pitchY + pitchY/2.
 
-        self.absX=self.relX - npix_X*pitchX/2.
-        self.absY=self.relY - npix_Y*pitchY/2.
+        self.absX=self.relX - halfChip_X
+        self.absY=self.relY - halfChip_Y
         self.absZ=0
 
 #
@@ -370,14 +370,14 @@ class Cluster:
             self.GetQWeightedCentroid()
 
 
-        self.absX = self.relX - npix_X*pitchX/2.
-        self.absY = self.relY - npix_Y*pitchY/2.
+        self.absX = self.relX - halfChip_X
+        self.absY = self.relY - halfChip_Y
         self.absZ = 0
-        self.absX_energyGC = self.relX_energyGC - npix_X*pitchX/2.
-        self.absY_energyGC = self.relY_energyGC - npix_Y*pitchY/2.
+        self.absX_energyGC = self.relX_energyGC - halfChip_X
+        self.absY_energyGC = self.relY_energyGC - halfChip_Y
         self.absZ_energyGC = 0
-        self.absX_energyPbPC = self.relX_energyPbPC - npix_X*pitchX/2.
-        self.absY_energyPbPC = self.relY_energyPbPC - npix_Y*pitchY/2.
+        self.absX_energyPbPC = self.relX_energyPbPC - halfChip_X
+        self.absY_energyPbPC = self.relY_energyPbPC - halfChip_Y
         self.absZ_energyPbPC = 0
 
 

--- a/ComputeAlignment.py
+++ b/ComputeAlignment.py
@@ -143,6 +143,14 @@ prev_pixel_xhits = [999, 999]
 clusters_tmp = []
 last_time=time.time()
 
+# Load hot pixels
+hotpixel_filename = "%s/Run%i/HotPixels_%i_0.01.txt" %(PlotPath,RunNumber,RunNumber)
+print "Hotpixel filename:", hotpixel_filename
+if os.path.isfile(hotpixel_filename):
+    aDataSet.LoadHotPixel(hotpixel_filename)
+else:
+    print "WARNING no hot pixel file found. No hot pixels set"
+
 for i in range(0,n_proc) :
     aDataSet.getEvent(i)
 

--- a/ComputeAlignment.py
+++ b/ComputeAlignment.py
@@ -136,7 +136,7 @@ else:
     skip = 1
 print "Running on run %i, with method %s, on %i events with skip %i" %(RunNumber,method_name,n_proc,skip)
 
-AlignmentPath = "%s/Run%i/alignment_%i_%s_%i_%i.dat" %(PlotPath,RunNumber,RunNumber,method_name,int(options.NEVENT),skip)
+AlignmentPath = "%s/Run%i/alignment_%i_%s_%i_%i.txt" %(PlotPath,RunNumber,RunNumber,method_name,int(options.NEVENT),skip)
 print "Alignment path will be", AlignmentPath
 
 prev_pixel_xhits = [999, 999]

--- a/EudetData.py
+++ b/EudetData.py
@@ -645,12 +645,12 @@ class EudetData:
         return is_in
 
 
-    def IsInGoodRegion(self,track,dut=6) : 
-    
-        if (track.trackX[track.iden.index(dut)]>=((pitchX*npix_X)/2-4*pitchX) and track.trackX[track.iden.index(dut)]<=((pitchX*npix_X)/2)) and (track.trackY[track.iden.index(dut)]>=(-(pitchY*npix_Y)/2.) and track.trackY[track.iden.index(dut)]<=((pitchY*npix_Y)/2.)) :
- 	    return true
+    def IsInMain(self,track,dut=6) : 
+
+        if(fabs(track.trackX[track.iden.index(dut)])<=(halfChip_X) and fabs(track.trackY[track.iden.index(dut)])<=(halfChip_Y)):
+ 	    return True
 	else : 
-	    return false
+	    return False
 
     def ComputeResiduals(self,i,dut=6) :
 
@@ -763,8 +763,8 @@ class EudetData:
                 aTrack.trackY = posY_tmp[j*ndata:j*ndata+ndata]
                 for index,element in enumerate(aTrack.trackX) :
     #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!1
-                    aTrack.trackX[index] = aTrack.trackX[index]-npix_X*pitchX/2.-pitchX/2.
-                    aTrack.trackY[index] = aTrack.trackY[index]-npix_Y*pitchY/2.-pitchY/2.
+                    aTrack.trackX[index] = aTrack.trackX[index]-halfChip_X-pitchX/2.
+                    aTrack.trackY[index] = aTrack.trackY[index]-halfChip_Y-pitchY/2.
                 aTrack.iden = iden_tmp[j*ndata:j*ndata+ndata]
                 aTrack.chi2 = chi2_tmp[j*ndata:j*ndata+ndata]
                 aTrack.trackNum = trackNum_tmp[j*ndata:j*ndata+ndata]

--- a/EudetData.py
+++ b/EudetData.py
@@ -664,10 +664,10 @@ class EudetData:
                     if cluster.id == track.cluster  :
                         cluster.GetResiduals(track.trackX[track.iden.index(dut)],track.trackY[track.iden.index(dut)])
 
-                        if(self.IsInEdges(track, dut)):
-                            nmatch_in_edge += 1.
-                        else :
+                        if(self.IsInMain(track, dut)):
                             nmatch_in_main += 1.
+                        elif(self.IsInEdges(track, dut)):
+                            nmatch_in_edge += 1.
 
         return nmatch_in_main, nmatch_in_edge
 
@@ -816,21 +816,16 @@ class EudetData:
 
                 cluster = clusters_tmp[distances.index(min(distances))]
 
-                if ((fabs(track.trackX[dut_iden])<=(halfChip_X+self.edge+TrackingRes))and(fabs(track.trackY[dut_iden])<=(halfChip_Y+self.edge+TrackingRes))):
-                    if (min(distances) < r_max) :
-                        # matched cluster
-                        cluster.id = good_count
-                        track.cluster = cluster.id
-                        cluster.tracknum = track.trackNum[dut_iden]
-                        matched_clusters.append(cluster)
-                        good_count += 1
-
-                    else :
-                        # unmatched cluster
-                        track.cluster = -11
+                if (min(distances) < r_max) :
+                    # matched cluster
+                    cluster.id = good_count
+                    track.cluster = cluster.id
+                    cluster.tracknum = track.trackNum[dut_iden]
+                    matched_clusters.append(cluster)
+                    good_count += 1
 
                 else :
-                    # track outside DUT
+                    # unmatched cluster
                     track.cluster = -11
 
             else :

--- a/ToolBox.py
+++ b/ToolBox.py
@@ -1125,7 +1125,7 @@ def EdgeEfficiency(aDataSet,dut) :
 
     TotalTrack = TH1D("TotalTrack","Track distribution in edge",140,-0.07,0.07)
     MatchedTrack = TH1D("MatchedTrack","Matched track distribution in edge",140,-0.07,0.07)
-    TOT_vs_edge = TH2D("TOT_vs_edge","TOT vs track position in edge",140,-0.07,0.07,200,0,1000)
+    TOT_vs_edge = TH2D("TOT_vs_edge","TOT vs track position in edge",140,-0.07,0.07,200,0,3000)
 
     edge_tracks = []
     edge_matched = []
@@ -1187,17 +1187,17 @@ def EdgeEfficiency(aDataSet,dut) :
 
 
 def ComputeEfficiency(aDataSet,n_matched,n_matched_edge,edge,PlotPath, dut=6):
-    n_tracks_in_total = ComputeDetectorAcceptance(aDataSet,dut,edge)
+    n_tracks_in_mainplusedge = ComputeDetectorAcceptance(aDataSet,dut,edge)
     n_tracks_in_main = ComputeDetectorAcceptance(aDataSet, dut,0)
-    n_tracks_in_edge = n_tracks_in_total - n_tracks_in_main
+    n_tracks_in_edge = n_tracks_in_mainplusedge - n_tracks_in_main
 
-    print "n_tracks_in_total", n_tracks_in_total
+    print "n_tracks_in_mainplusedge", n_tracks_in_mainplusedge
     print "n_tracks_in_main", n_tracks_in_main
     print "n_tracks_in_edge", n_tracks_in_edge
 
     efficiency_in_main = 0.
     efficiency_in_edge = 0.
-    efficiency_in_total = 0.
+    efficiency_in_mainplusedge = 0.
 
     if n_tracks_in_main != 0 :
         efficiency_in_main = float(n_matched)/n_tracks_in_main
@@ -1209,19 +1209,19 @@ def ComputeEfficiency(aDataSet,n_matched,n_matched_edge,edge,PlotPath, dut=6):
     else:
         efficiency_in_edge = 0.
 
-    if n_tracks_in_total != 0. :
-        efficiency_in_total = float(n_matched + n_matched_edge)/n_tracks_in_total
+    if n_tracks_in_mainplusedge != 0. :
+        efficiency_in_mainplusedge = float(n_matched + n_matched_edge)/n_tracks_in_mainplusedge
     else:
-        efficiency_in_total = 0.
+        efficiency_in_mainplusedge = 0.
        
     print "Efficiency in main : %f %%"%(efficiency_in_main*100)
     print "Efficiency in edge : %f %%"%(efficiency_in_edge*100)
-    print "Efficiency in total : %f %%"%(efficiency_in_total*100)
+    print "Efficiency in mainplusedge : %f %%"%(efficiency_in_mainplusedge*100)
 
     f = open("%s/Efficiency.txt"%PlotPath,'w')
     f.write("Efficiency in main : %f %%\n"%(efficiency_in_main*100))
     f.write("Efficiency in edge : %f %%\n"%(efficiency_in_edge*100))
-    f.write("Efficiency in total : %f %%\n"%(efficiency_in_total*100))
+    f.write("Efficiency in mainplusedge : %f %%\n"%(efficiency_in_mainplusedge*100))
     f.close()
 
 

--- a/ToolBox.py
+++ b/ToolBox.py
@@ -1000,6 +1000,7 @@ def FindSigmaMin(dataSet,nevent,PlotPath,RunNumber,method_name, skip=1, dut=6) :
     bestsigma=1000
     bestres=1000
     sigmaint_max = 500
+    print "Looking for SigmaMin for TOT"
     for sigmaint in range(sigmaint_max) :
     	sigma=sigmaint*1e-4
         
@@ -1024,6 +1025,7 @@ def FindSigmaMin(dataSet,nevent,PlotPath,RunNumber,method_name, skip=1, dut=6) :
         bestsigmaGC=1000
         bestresGC=1000
         sigmaintGC_max = 500
+        print "Looking for SigmaMin for GC"
         for sigmaintGC in range(sigmaintGC_max) :
             sigmaGC=sigmaintGC*1e-4
 
@@ -1042,6 +1044,7 @@ def FindSigmaMin(dataSet,nevent,PlotPath,RunNumber,method_name, skip=1, dut=6) :
         bestsigmaPbPC=1000
         bestresPbPC=1000
         sigmaintPbPC_max = 500
+        print "Looking for SigmaMin for PbPC"
         for sigmaintPbPC in range(sigmaintPbPC_max) :
             sigmaPbPC=sigmaintPbPC*1e-4
 
@@ -1122,58 +1125,57 @@ def ApplyEtaCorrection(dataSet,ressigmachargeX,ressigmachargeY,dut=6,filename="E
 
 def EdgeEfficiency(aDataSet,dut) :
 
-    TotalTrack = TH1D("TotalTrack","Track distribution in edge",50,0,aDataSet.edge)
-    MatchedTrack = TH1D("MatchedTrack","Matched track distribution in edge",50,0,aDataSet.edge)
-    TOT_vs_edge = TH2D("TOT_vs_edge","TOT vs track position in edge",50,0,aDataSet.edge,200,0,1000)
+    TotalTrack = TH1D("TotalTrack","Track distribution in edge",140,-0.07,0.07)
+    MatchedTrack = TH1D("MatchedTrack","Matched track distribution in edge",140,-0.07,0.07)
+    TOT_vs_edge = TH2D("TOT_vs_edge","TOT vs track position in edge",140,-0.07,0.07,200,0,1000)
 
     edge_tracks = []
     edge_matched = []
     edge_efficiencies = []
     for i in range(4):
-        TotalTrack_edge = TH1D("TotalTrack_edge_%i"%i,"Track distribution in edge %i" %i,50,0,aDataSet.edge)
-        MatchedTrack_edge = TH1D("MatchedTrack_edge_%i"%i,"Matched track distribution in edge %i" %i,50,0,aDataSet.edge)
+        TotalTrack_edge = TH1D("TotalTrack_edge_%i"%i,"Track distribution in edge %i" %i,140,-0.07,0.07)
+        MatchedTrack_edge = TH1D("MatchedTrack_edge_%i"%i,"Matched track distribution in edge %i" %i,140,-0.07,0.07)
         edge_tracks.append(TotalTrack_edge)
         edge_matched.append(MatchedTrack_edge)
 
 
     for j,tracks in enumerate(aDataSet.AllTracks) :
         for track in tracks :
-            if(aDataSet.IsInEdges(track,dut)) :
-                if(fabs(track.trackX[track.iden.index(dut)])>halfChip_X and fabs(track.trackY[track.iden.index(dut)])<halfChip_Y):
-                    TotalTrack.Fill(fabs(track.trackX[track.iden.index(dut)])-halfChip_X)
+            if(fabs(track.trackX[track.iden.index(dut)])>(halfChip_X-0.07) and fabs(track.trackY[track.iden.index(dut)])<halfChip_Y):
+                TotalTrack.Fill(fabs(track.trackX[track.iden.index(dut)])-halfChip_X)
+                if(track.trackX[track.iden.index(dut)]>0) :
+                    edge_tracks[0].Fill(fabs(track.trackX[track.iden.index(dut)])-halfChip_X)
+                else :
+                    edge_tracks[2].Fill(fabs(track.trackX[track.iden.index(dut)])-halfChip_X)
+
+                if track.cluster!=-11 and len(aDataSet.AllClusters[j])!=0 :
+                    MatchedTrack.Fill(fabs(track.trackX[track.iden.index(dut)])-halfChip_X)
+                    TOT_vs_edge.Fill(fabs(track.trackX[track.iden.index(dut)])-halfChip_X,aDataSet.AllClusters[j][track.cluster].totalTOT)
                     if(track.trackX[track.iden.index(dut)]>0) :
-                        edge_tracks[0].Fill(fabs(track.trackX[track.iden.index(dut)])-halfChip_X)
+                        edge_matched[0].Fill(fabs(track.trackX[track.iden.index(dut)])-halfChip_X)
                     else :
-                        edge_tracks[2].Fill(fabs(track.trackX[track.iden.index(dut)])-halfChip_X)
+                        edge_matched[2].Fill(fabs(track.trackX[track.iden.index(dut)])-halfChip_X)
 
-                    if track.cluster!=-11 and len(aDataSet.AllClusters[j])!=0 :
-                        MatchedTrack.Fill(fabs(track.trackX[track.iden.index(dut)])-halfChip_X)
-                        TOT_vs_edge.Fill(fabs(track.trackX[track.iden.index(dut)])-halfChip_X,aDataSet.AllClusters[j][track.cluster].totalTOT)
-                        if(track.trackX[track.iden.index(dut)]>0) :
-                            edge_matched[0].Fill(fabs(track.trackX[track.iden.index(dut)])-halfChip_X)
-                        else :
-                            edge_matched[2].Fill(fabs(track.trackX[track.iden.index(dut)])-halfChip_X)
+            if(fabs(track.trackX[track.iden.index(dut)])<halfChip_X and fabs(track.trackY[track.iden.index(dut)])>(halfChip_Y-0.07)):
+                TotalTrack.Fill(fabs(track.trackY[track.iden.index(dut)])-halfChip_Y)
+                if(track.trackY[track.iden.index(dut)]>0) :
+                    edge_tracks[1].Fill(fabs(track.trackY[track.iden.index(dut)])-halfChip_Y)
+                else :
+                    edge_tracks[3].Fill(fabs(track.trackY[track.iden.index(dut)])-halfChip_Y)
 
-                if(fabs(track.trackX[track.iden.index(dut)])<halfChip_X and fabs(track.trackY[track.iden.index(dut)])>halfChip_Y):
-                    TotalTrack.Fill(fabs(track.trackY[track.iden.index(dut)])-halfChip_Y)
+                if track.cluster!=-11 and len(aDataSet.AllClusters[j])!=0 :
+                    MatchedTrack.Fill(fabs(track.trackY[track.iden.index(dut)])-halfChip_Y)
+                    TOT_vs_edge.Fill(fabs(track.trackY[track.iden.index(dut)])-halfChip_Y,aDataSet.AllClusters[j][track.cluster].totalTOT)
                     if(track.trackY[track.iden.index(dut)]>0) :
-                        edge_tracks[1].Fill(fabs(track.trackY[track.iden.index(dut)])-halfChip_Y)
+                        edge_matched[1].Fill(fabs(track.trackY[track.iden.index(dut)])-halfChip_Y)
                     else :
-                        edge_tracks[3].Fill(fabs(track.trackY[track.iden.index(dut)])-halfChip_Y)
-
-                    if track.cluster!=-11 and len(aDataSet.AllClusters[j])!=0 :
-                        MatchedTrack.Fill(fabs(track.trackY[track.iden.index(dut)])-halfChip_Y)
-                        TOT_vs_edge.Fill(fabs(track.trackY[track.iden.index(dut)])-halfChip_Y,aDataSet.AllClusters[j][track.cluster].totalTOT)
-                        if(track.trackY[track.iden.index(dut)]>0) :
-                            edge_matched[1].Fill(fabs(track.trackY[track.iden.index(dut)])-halfChip_Y)
-                        else :
-                            edge_matched[3].Fill(fabs(track.trackY[track.iden.index(dut)])-halfChip_Y)
+                        edge_matched[3].Fill(fabs(track.trackY[track.iden.index(dut)])-halfChip_Y)
 
 
     for i in range(4):
         edge_tracks[i].SetLineColor(i+1)
         edge_matched[i].SetLineColor(i+1)
-        h = edge_matched[i].Clone("Efficiency")
+        h = edge_matched[i].Clone("Efficiency_%i" %i)
         h.Divide(edge_matched[i],edge_tracks[i],1.,1.,"B")
         h.SetTitle("Efficiency in edge %i"%i)
         edge_efficiencies.append(h)

--- a/ToolBox.py
+++ b/ToolBox.py
@@ -173,9 +173,7 @@ def ComputeDetectorAcceptance(dataSet, dut=6, edges = 0):
     last_time = time.time()
     for i,tracks in enumerate(dataSet.AllTracks) :
         for track in tracks :
-            #if (i%1000==0):
-                #print "Elapsed time for track in acceptance, event %i: %f s"%(i,(time.time()-last_time))
-            if (track.trackX[track.iden.index(dut)]>=(-(pitchX*npix_X)/2.-edges) and track.trackX[track.iden.index(dut)]<=((pitchX*npix_X)/2.+edges)) and (track.trackY[track.iden.index(dut)]>=(-(pitchY*npix_Y)/2.-edges) and track.trackY[track.iden.index(dut)]<=((pitchY*npix_Y)/2.+edges)) :
+            if (track.trackX[track.iden.index(dut)]>=(-halfChip_X-edges) and track.trackX[track.iden.index(dut)]<=(halfChip_X+edges)) and (track.trackY[track.iden.index(dut)]>=(-halfChip_Y-edges) and track.trackY[track.iden.index(dut)]<=(halfChip_Y+edges)) :
                 n_tracks_in+=1
     return n_tracks_in
 
@@ -518,8 +516,8 @@ def ClusterHitProb(dataSet,nbin,dut=6):
 
 def TrackClusterCorrelation(dataSet,dut=6,imax=1000):
 
-    histox = TH2D("corX","Track-cluster x correlation",npix_X,-(npix_X)*pitchX/2.,npix_X*pitchX/2.,npix_X,-(npix_X)*pitchX/2.,npix_X*pitchX/2.)
-    histoy = TH2D("corY","Track-cluster y correlation",npix_Y,-(npix_Y)*pitchY/2.,npix_Y*pitchY/2.,npix_Y,-(npix_Y)*pitchY/2.,npix_Y*pitchY/2.)
+    histox = TH2D("corX","Track-cluster x correlation",npix_X,-halfChip_X,halfChip_X,npix_X,-halfChip_X,halfChip_X)
+    histoy = TH2D("corY","Track-cluster y correlation",npix_Y,-halfChip_Y,halfChip_Y,npix_Y,-halfChip_Y,halfChip_Y)
 
     for h in [histox,histoy] :
         h.GetXaxis().SetTitle("Cluster position (mm)")

--- a/pyEudetAnalysisOnly.py
+++ b/pyEudetAnalysisOnly.py
@@ -208,39 +208,40 @@ print "Running on run %i, with Method %s, on %i Events"%(RunNumber,method_name,n
 
 
 # EdgeEfficiency
-if aDataSet.edge != 0.0:
-    TotalTrack, MatchedTrack, Efficiency, edge_tracks, edge_matched, edge_efficiencies, TOT_vs_edge = EdgeEfficiency(aDataSet,dutID)
+TotalTrack, MatchedTrack, Efficiency, edge_tracks, edge_matched, edge_efficiencies, TOT_vs_edge = EdgeEfficiency(aDataSet,dutID)
 
-    eff_can = TCanvas()
-    MatchedTrack.Draw("")
-    eff_can.SaveAs("%s/Run%i/%s/Edge_MatchedTracks.pdf"%(PlotPath,RunNumber,method_name))
+eff_can = TCanvas()
+MatchedTrack.Draw("")
+eff_can.SaveAs("%s/Run%i/%s/Edge_MatchedTracks.pdf"%(PlotPath,RunNumber,method_name))
 
-    Efficiency.Draw("")
-    eff_can.SaveAs("%s/Run%i/%s/Edge_Efficiency.pdf"%(PlotPath,RunNumber,method_name))
+Efficiency.Draw("")
+eff_can.SaveAs("%s/Run%i/%s/Edge_Efficiency.pdf"%(PlotPath,RunNumber,method_name))
 
-    TOT_vs_edge.Draw("colz")
-    eff_can.SaveAs("%s/Run%i/%s/Edge_TOT.pdf"%(PlotPath,RunNumber,method_name))
+TOT_vs_edge.Draw("colz")
+eff_can.SaveAs("%s/Run%i/%s/Edge_TOT.pdf"%(PlotPath,RunNumber,method_name))
 
-    TotalTrack.Draw("")
-    eff_can.SaveAs("%s/Run%i/%s/Edge_Tracks.pdf"%(PlotPath,RunNumber,method_name))
+TotalTrack.Draw("")
+eff_can.SaveAs("%s/Run%i/%s/Edge_Tracks.pdf"%(PlotPath,RunNumber,method_name))
 
-    edge_efficiencies[0].Draw("")
-    for i in range(1,4) :
-        edge_efficiencies[i].Draw("same")
-    eff_can.BuildLegend()
-    eff_can.SaveAs("%s/Run%i/%s/Edge_Efficiency_edge_by_edge.pdf"%(PlotPath,RunNumber,method_name))
+edge_efficiencies[0].Draw("")
+for i in range(1,4) :
+    edge_efficiencies[i].Draw("same")
+eff_can.BuildLegend()
+eff_can.SaveAs("%s/Run%i/%s/Edge_Efficiency_edge_by_edge.pdf"%(PlotPath,RunNumber,method_name))
 
-    edge_matched[0].Draw("")
-    for i in range(1,4) :
-        edge_matched[i].Draw("same")
-    eff_can.BuildLegend()
-    eff_can.SaveAs("%s/Run%i/%s/Edge_MatchedTracks_edge_by_edge.pdf"%(PlotPath,RunNumber,method_name))
+edge_matched[0].SetMinimum(0)
+edge_matched[0].Draw("")
+for i in range(1,4) :
+    edge_matched[i].Draw("same")
+eff_can.BuildLegend()
+eff_can.SaveAs("%s/Run%i/%s/Edge_MatchedTracks_edge_by_edge.pdf"%(PlotPath,RunNumber,method_name))
 
-    edge_tracks[0].Draw("")
-    for i in range(1,4) :
-        edge_tracks[i].Draw("same")
-    eff_can.BuildLegend()
-    eff_can.SaveAs("%s/Run%i/%s/Edge_Tracks_edge_by_edge.pdf"%(PlotPath,RunNumber,method_name))
+edge_tracks[0].SetMinimum(0)
+edge_tracks[0].Draw("")
+for i in range(1,4) :
+    edge_tracks[i].Draw("same")
+eff_can.BuildLegend()
+eff_can.SaveAs("%s/Run%i/%s/Edge_Tracks_edge_by_edge.pdf"%(PlotPath,RunNumber,method_name))
 
 
 # ComputeEfficiency
@@ -1220,15 +1221,14 @@ out.cd()
 
 h_chi2.Write()
 h_chi2ndof.Write()
-if aDataSet.edge != 0.0:
-    MatchedTrack.Write()
-    Efficiency.Write()
-    TOT_vs_edge.Write()
-    TotalTrack.Write()
-    for i in range(4) :
-        edge_efficiencies[i].Write()
-        edge_matched[i].Write()
-        edge_tracks[i].Write()
+MatchedTrack.Write()
+Efficiency.Write()
+TOT_vs_edge.Write()
+TotalTrack.Write()
+for i in range(4) :
+    edge_efficiencies[i].Write()
+    edge_matched[i].Write()
+    edge_tracks[i].Write()
 hClusterSize.Write()
 hClusterSizeX.Write()
 hClusterSizeY.Write()


### PR DESCRIPTION
If a hot pixel file exists for the run being aligned, it will be loaded and identified hot pixels will be removed. 

This is the 'correct' thing to do. It has no effect for runs with low numbers of hot pixels. For runs with high number of hot pixels, I see better results when the hot pixels are removed. 